### PR TITLE
Script updates

### DIFF
--- a/README/inputs.conf.spec
+++ b/README/inputs.conf.spec
@@ -1,0 +1,15 @@
+## Configurations to pass btool checks without throwing errors
+
+[script:<uniqueName>]
+deploymentServerUri = [string]
+* Correct URI that should be configured
+
+deploymentClientApp = [string]
+* App name that contains the correct deploymentclient.conf configuration
+
+[powershell:<uniqueName>]
+deploymentServerUri = [string]
+* Correct URI that should be configured with port
+
+deploymentClientApp = [string]
+* App name that contains the correct deploymentclient.conf configuration

--- a/bin/appContext.sh
+++ b/bin/appContext.sh
@@ -2,3 +2,11 @@
 ## Grab the current app context
 SCRIPT_PATH=$(realpath $0)
 APP_PATH=$(dirname ${SCRIPT_PATH})
+SCRIPT_NAME=$(echo ${SCRIPT_PATH} | sed "s|${APP_PATH}/||")
+APP_NAME=$(echo ${SCRIPT_PATH} | sed "s|${SPLUNK_HOME}/etc/apps" | sed "s|/${SCRIPT_NAME}||")
+
+## Capture the deploymentServerUri from the inputs stanza
+if [ "${SCRIPT_NAME}" = "dsRemove.sh" ]; then
+  CORRECT_DS=$(${SPLUNK_HOME}/bin/splunk btool --app=$APP_NAME inputs list script://./bin/$SCRIPT_NAME | grep deploymentServerUri | sed "s/deploymentServerUri = //")
+  CORRECT_APP=$(${SPLUNK_HOME}/bin/splunk btool --app=$APP_NAME inputs list script://./bin/$SCRIPT_NAME | grep deploymentClientApp | sed "s/deploymentClientApp = //")
+fi

--- a/bin/dateTimeCorrect.ps1
+++ b/bin/dateTimeCorrect.ps1
@@ -4,7 +4,7 @@ $referenceDateTime = "$SPLUNKHOME\apps\SplunkForwarderRepairKit\datetime.xml"
 $restartDateTimeCheck = "$SPLUNKHOME\etc\restartdatetime.txt"
 
 ### Filter to attach timestamps where necessary
-filter timestamp {"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff') ${env:COMPUTERNAME}: $_"}
+filter timestamp {"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff zzz') ${env:COMPUTERNAME}: $_"}
 
 ### Check flags and take appropriate actions for host name
 if(Compare-Object -ReferenceObject $(Get-Content $existingDateTime) -DifferenceObject $(Get-Content $referenceDateTime)) {

--- a/bin/dateTimeCorrect.sh
+++ b/bin/dateTimeCorrect.sh
@@ -7,9 +7,9 @@ RESTART_DATETIME_CHECK="$SPLUNK_HOME/etc/restartdatetime.txt"
 
 ### Determine if a correction is necessary
 if [ $DATETIME_DIFFERENCE = 0 ]; then
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: The datetime.xml is the updated version. No correction necessary..."
+	echo "$(date -R) ${HOSTNAME}: The datetime.xml is the updated version. No correction necessary..."
 else
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: The datetime.xml file needs to be updated. Updating..."
+	echo "$(date -R) ${HOSTNAME}: The datetime.xml file needs to be updated. Updating..."
 	mv $EXISTING_DATETIME $EXISTING_DATETIME.$(date +"%m%d%Y")
 	cp $REFERENCE_DATETIME $EXISTING_DATETIME
 	touch $RESTART_DATETIME_CHECK

--- a/bin/dsRemove.ps1
+++ b/bin/dsRemove.ps1
@@ -1,21 +1,57 @@
+### Grab variables from inputs.conf
+$BTOOL_INPUT = & $SPLUNKHOME\bin\splunk.exe cmd btool inputs list powershell://dsRemove --debug
+$SFRK_APP = ($BTOOL_INPUT -replace [regex]::Escape("$SPLUNKHOME\etc\apps\"),"" -replace "\\(default|local)\\inputs.conf","").Split(" ")[0]
+$CORRECT_DS_LINE = ($BTOOL_INPUT | findstr deploymentServerUri)
+$CORRECT_DS_APP_LINE = ($BTOOL_INPUT | findstr deploymentClientApp)
+$CORRECT_DS = ("$CORRECT_DS_LINE" -replace [regex]::Escape("$SPLUNKHOME\etc\apps\"),"").Split(" ")[3]
+$CORRECT_DS_APP = ("$CORRECT_DS_APP_LINE" -replace [regex]::Escape("$SPLUNKHOME\etc\apps\"),"").Split(" ")[3]
+
+if (!$CORRECT_DS) {
+  Write-output "deploymentServerUri not configured in inputs.conf" | timestamp
+  exit
+}
+
+if (!$CORRECT_DS_APP) {
+  Write-output "deploymentClientApp not configured in inputs.conf" | timestamp
+  exit
+}
+
 ### Configure file paths for the system
-$LOCAL = {$((Get-ChildItem -Path "$SPLUNKHOME\etc\system\local" -Include deploymentclient.conf -File -Recurse).Count)}
-$DEPLOYED = {$((Get-ChildItem -Path "$SPLUNKHOME\etc\apps" -Include deploymentclient.conf -File -Recurse).Count)}
+$LOCAL = $((Get-ChildItem -Path "$SPLUNKHOME\etc\system\local" -Include deploymentclient.conf -File -Recurse).Count)
+$DEPLOYED = $((Get-ChildItem -Path "$SPLUNKHOME\etc\apps" -Include deploymentclient.conf -File -Recurse).Count)
+$LIST_APPS = $(Get-ChildItem -Path "$SPLUNKHOME\etc\apps" -Include deploymentclient.conf -File -Recurse)
+$BAD_APPS = @(($LIST_APPS -replace "(deafult|local)\\deploymentclient.conf","").where{$_ -notmatch [regex]::Escape("$CORRECT_DS_APP") })
 $RESTART_CHECK = "$SPLUNKHOME\etc\restartds.txt"
 
 ### Filter to attach timestamps where necessary
-filter timestamp {"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff') ${env:COMPUTERNAME}: $_"}
+filter timestamp {"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff zzz') ${env:COMPUTERNAME}: $_"}
+
+## Capture the current configuration that Splunk is using from btool
+$BTOOL = & $SPLUNKHOME\bin\splunk.exe cmd btool deploymentclient list --debug | FINDSTR 'targetUri'
+$CURRENT_DS = ($BTOOL -replace [regex]::Escape("$SPLUNKHOME"),"").Split(" ")[3]
+$CURRENT_APP_PATH = "$SPLUNKHOME"+($BTOOL -replace [regex]::Escape("$SPLUNKHOME"),"" -replace "\\(deafult|local)\\deploymentclient.conf","").Split(" ")[0]
+$CURRENT_APP_NAME = ($CURRENT_APP_PATH -replace [regex]::Escape("$SPLUNKHOME\etc\apps\"),"")
 
 ### Check to see if there is a deploymentclient.conf file under $SPLUNKHOME\etc\apps and bail out if there isn't
 if ($DEPLOYED -eq "0") {
-    Write-output "No deploymentclient.conf detected in $SPLUNKHOME\etc\apps. Bailing out so the fowarder doesn't get orphaned." | timestamp
-} elseif ($DEPLOYED -gt "1") {
-    Write-output "Multiple deploymentclient.conf detected in $SPLUNKHOME\etc\apps. Check all deployed apps to ensure you\'re only using one." | timestamp
-} elseif ($LOCAL -eq "1" -AND $DEPLOYED -eq "1") {
-    ### Remove the local "deploymentclient.conf" and flag
-    Write-output "Removed deploymentclient.conf from local system." | timestamp
-    Remove-Item -Path "$LOCAL"
-    Out-File -FilePath "$RESTART_CHECK"
-} else {
-    Write-output "No deploymentclient.conf correction necessary." | timestamp
+  Write-output "No deploymentclient.conf detected in $SPLUNKHOME\etc\apps. Bailing out so the fowarder doesn't get orphaned." | timestamp
+  Write-output "Deploy $CORRECT_APP to this server to correct this issue." | timestamp
+}
+elseif ($DEPLOYED -gt "1") {
+  Write-output "Multiple deploymentclient.conf detected in $SPLUNKHOME\etc\apps." | timestamp
+  Write-output "Removing bad app(s) to ensure there is no contention with $CORRECT_DS_APP" | timestamp
+  foreach ($item in $BAD_APPS)
+  {
+    Remove-Item -Path "$item" -Force -Recurse -Confirm
+    Write-output "Removed app: $item" | timestamp
+  }
+  Out-File -FilePath "$RESTART_CHECK"
+}
+elseif ($LOCAL -eq "1" -AND $DEPLOYED -eq "1") {
+  Write-output "Removed deploymentclient.conf from local system." | timestamp
+  Remove-Item -Path "$LOCAL" -Force -Confirm
+  Out-File -FilePath "$RESTART_CHECK"
+}
+else {
+  Write-output "No deploymentclient.conf correction necessary." | timestamp
 }

--- a/bin/dsRemove.sh
+++ b/bin/dsRemove.sh
@@ -6,33 +6,41 @@
 ### Look for a deploymentclient.conf file in the apps directory and define the path to the restartds.txt file
 CORRECT_APP_DEPLOYED=$(find $SPLUNK_HOME/etc/apps -type d -name ${CORRECT_APP} | wc -l)
 DEPLOYED_APP=$(find $SPLUNK_HOME/etc/apps -type f -name deploymentclient.conf | wc -l)
+BAD_APPS=($(find $SPLUNK_HOME/etc/apps -type f -name deploymentclient.conf | grep -v ${CORRECT_APP} | sed "s/\/(default|local)\/deploymentclient.conf//"))
 LOCAL=$(find $SPLUNK_HOME/etc/system/local -type f -name deploymentclient.conf | wc -l)
 RESTART_CHECK=$SPLUNK_HOME/etc/restartds.txt
 
 ## Capture the current deployment server URI from btool
 BTOOL=$(${SPLUNK_HOME}/bin/splunk btool deploymentclient list --debug | grep targetUri)
 CURRENT_DS=$(echo ${BTOOL} | awk '{print $4}')
-CURRENT_APP_PATH=$(echo ${BTOOL} | awk '{print $1}' | sed "s/\/(default|local)\/deploymentclient.conf//"
+CURRENT_APP_PATH=$(echo ${BTOOL} | awk '{print $1}' | sed "s/\/(default|local)\/deploymentclient.conf//")
 CURRENT_APP_NAME=$(echo ${CURRENT_APP_PATH} | sed "s|${SPLUNK_HOME}\/etc\/apps\/||")
+
+## Check for inputs configurations and bail out if they don't exist
+if [ -z "${CORRECT_DS}" ] || [ -z "${CORRECT_APP}" ]; then
+  echo "$(date -R) $HOSTNAME: Missing configurations in inputs.conf."
+  exit 1
+fi
 
 ## If there is no deployed app with a deployment client, bail out
 if [ $DEPLOYED_APP = "0" ]; then
   echo "$(date -R) $HOSTNAME: No deploymentclient.conf detected in $SPLUNK_HOME/etc/apps. Bailing out so the fowarder doesn\'t get orphaned."
-  echo "$(date -R) $HOSTNAME: Deploy \"${CURRENT_APP_NAME}\" to this server to correct this issue."
+  echo "$(date -R) $HOSTNAME: Deploy \"${CORRECT_APP}\" to this server to correct this issue."
   exit 1
 fi
 
 ## If more than one deploymentclient.conf file is deployed, nuke the wrong app and set the checkpoint file
 if [ $DEPLOYED_APP > "1" ]; then
   echo "$(date -R) $HOSTNAME: Multiple apps with deploymentclient.conf detected in $SPLUNK_HOME/etc/apps."
-  echo "$(date -R) $HOSTNAME: Removing ${CURRENT_APP_NAME} to ensure there is no contention with ${CORRECT_APP}"
-  rm -rf "${CURRENT_APP_PATH}"
+  echo "$(date -R) $HOSTNAME: Removing bad apps to ensure there is no contention with \"${CORRECT_APP}\""
+  for i in "${BAD_APPS[@]}"; do
+    rm -rf $i
+  done
   touch $RESTART_CHECK
 fi
 
 ## If there's 1 local config, remove the local one and set the checkpoint file
 if [ $LOCAL = "1" ]; then
-  # Remove the deploymentclient.conf from $SPLUNK_HOME/etc/system/local
   rm -f $SPLUNK_HOME/etc/system/local/deploymentclient.conf > /dev/null 2>&1
   echo $(date -R) $HOSTNAME: Removed deploymentclient.conf from local system.
   touch $RESTART_CHECK

--- a/bin/dsRemove.sh
+++ b/bin/dsRemove.sh
@@ -1,24 +1,44 @@
 #!/bin/bash
+
+## Run appContext to capture details from inputs stanza
+. $(dirname $0)/appContext.sh
+
 ### Look for a deploymentclient.conf file in the apps directory and define the path to the restartds.txt file
+CORRECT_APP_DEPLOYED=$(find $SPLUNK_HOME/etc/apps -type d -name ${CORRECT_APP} | wc -l)
 DEPLOYED_APP=$(find $SPLUNK_HOME/etc/apps -type f -name deploymentclient.conf | wc -l)
 LOCAL=$(find $SPLUNK_HOME/etc/system/local -type f -name deploymentclient.conf | wc -l)
 RESTART_CHECK=$SPLUNK_HOME/etc/restartds.txt
 
-### Check variables and take action accordingly
+## Capture the current deployment server URI from btool
+BTOOL=$(${SPLUNK_HOME}/bin/splunk btool deploymentclient list --debug | grep targetUri)
+CURRENT_DS=$(echo ${BTOOL} | awk '{print $4}')
+CURRENT_APP_PATH=$(echo ${BTOOL} | awk '{print $1}' | sed "s/\/(default|local)\/deploymentclient.conf//"
+CURRENT_APP_NAME=$(echo ${CURRENT_APP_PATH} | sed "s|${SPLUNK_HOME}\/etc\/apps\/||")
+
 ## If there is no deployed app with a deployment client, bail out
 if [ $DEPLOYED_APP = "0" ]; then
-        echo $(date -R) $HOSTNAME: No deploymentclient.conf detected in $SPLUNK_HOME/etc/apps. Bailing out so the fowarder doesn\'t get orphaned.
-        exit 1
-      ## If more than one deploymentclient.conf file is deployed, bail out
-      elif [ $DEPLOYED_APP > "1" ]; then
-        echo $(date -R) $HOSTNAME: Multiple deploymentclient.conf detected in $SPLUNK_HOME/etc/apps. Check all deployed apps to ensure you\'re only using one.
-        exit 1
-      ## If there's 1 local config and 1 deployed config, remove the local one and set the checkpoint file
-      elif [ $LOCAL = "1" ] & [ $DEPLOYED_APP = "1" ]; then
-        # Remove the deploymentclient.conf from $SPLUNK_HOME/etc/system/local
-        rm -f $SPLUNK_HOME/etc/system/local/deploymentclient.conf > /dev/null 2>&1
-        echo $(date -R) $HOSTNAME: Removed deploymentclient.conf from local system.
-        touch $RESTART_CHECK
-      else
-        echo $(date -R) $HOSTNAME: No deploymentclient.conf correction necessary.
+  echo "$(date -R) $HOSTNAME: No deploymentclient.conf detected in $SPLUNK_HOME/etc/apps. Bailing out so the fowarder doesn\'t get orphaned."
+  echo "$(date -R) $HOSTNAME: Deploy \"${CURRENT_APP_NAME}\" to this server to correct this issue."
+  exit 1
+fi
+
+## If more than one deploymentclient.conf file is deployed, nuke the wrong app and set the checkpoint file
+if [ $DEPLOYED_APP > "1" ]; then
+  echo "$(date -R) $HOSTNAME: Multiple apps with deploymentclient.conf detected in $SPLUNK_HOME/etc/apps."
+  echo "$(date -R) $HOSTNAME: Removing ${CURRENT_APP_NAME} to ensure there is no contention with ${CORRECT_APP}"
+  rm -rf "${CURRENT_APP_PATH}"
+  touch $RESTART_CHECK
+fi
+
+## If there's 1 local config, remove the local one and set the checkpoint file
+if [ $LOCAL = "1" ]; then
+  # Remove the deploymentclient.conf from $SPLUNK_HOME/etc/system/local
+  rm -f $SPLUNK_HOME/etc/system/local/deploymentclient.conf > /dev/null 2>&1
+  echo $(date -R) $HOSTNAME: Removed deploymentclient.conf from local system.
+  touch $RESTART_CHECK
+fi
+
+## If the current deployment server is configured and the correct app is installed, bail out
+if [ "${CURRENT_DS}" = "${CORRECT_DS}" ] && [ "${CURRENT_APP}" = "${CORRECT_APP}" ]; then
+  echo $(date -R) $HOSTNAME: No deploymentclient.conf correction necessary.
 fi

--- a/bin/hostCorrect.ps1
+++ b/bin/hostCorrect.ps1
@@ -6,7 +6,7 @@ $restartInputCheck = "$SPLUNKHOME\etc\restartinput.txt"
 $restartServerCheck = "$SPLUNKHOME\etc\restartserver.txt"
 
 ### Filter to attach timestamps where necessary
-filter timestamp {"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff') ${env:COMPUTERNAME}: $_"}
+filter timestamp {"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff zzz') ${env:COMPUTERNAME}: $_"}
 
 ### Compare values to actual host value and flag accordingly
 if (-not ($currentHost -eq $env:COMPUTERNAME)){

--- a/bin/hostCorrect.sh
+++ b/bin/hostCorrect.sh
@@ -9,7 +9,7 @@ RESTART_SERVER_CHECK="$SPLUNK_HOME/etc/restartserver.txt"
 if [ -f "$INPUTS_FILE" ]; then
 	CURRENT_HOST=$(cat "$INPUTS_FILE" | grep "host =" | awk '{printf $3}')
 else
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: Inputs file is missing from local config. Creating it now..."
+	echo "$(date -R) ${HOSTNAME}: Inputs file is missing from local config. Creating it now..."
 	touch "$INPUTS_FILE"
 	echo "[default]
 	host = IntentionallyWrong" > "$INPUTS_FILE"
@@ -19,7 +19,7 @@ fi
 ### Check for the existence of a serverName value and insert one if one isn't configured
 CURRENT_SERVER=$(cat "$SERVER_FILE" | grep "serverName =" | awk '{printf $3}')
 if [ -z "$CURRENT_SERVER" ]; then
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: There is no serverName value configured. Inserting one..."
+	echo "$(date -R) ${HOSTNAME}: There is no serverName value configured. Inserting one..."
 	echo "
 	[general]
 	serverName = IntentionallyWrong" >> "$SERVER_FILE"
@@ -28,17 +28,17 @@ fi
 
 ### Check the current values of the configured files and correct if necessary
 if [ "$CURRENT_HOST" = "$HOSTNAME" ]; then
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: Currently configured host name: $CURRENT_HOST. No correction necessary..."
+	echo "$(date -R) ${HOSTNAME}: Currently configured host name: $CURRENT_HOST. No correction necessary..."
 else
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: Currently configured host name: $CURRENT_HOST. Reconfiguring inputs.conf..."
+	echo "$(date -R) ${HOSTNAME}: Currently configured host name: $CURRENT_HOST. Reconfiguring inputs.conf..."
 	cp "$INPUTS_FILE" "$INPUTS_FILE".$(date +"%m%d%Y")
 	sed -i "s/$CURRENT_HOST/$HOSTNAME/" "$INPUTS_FILE"
 	touch "$RESTART_INPUT_CHECK"
 fi
 if [ "$CURRENT_SERVER" = "$HOSTNAME" ]; then
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: Currently configured server name: $CURRENT_SERVER. No correction necessary..."
+	echo "$(date -R) ${HOSTNAME}: Currently configured server name: $CURRENT_SERVER. No correction necessary..."
 else
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: Currently configured server name: $CURRENT_SERVER. Reconfiguring server.conf..."
+	echo "$(date -R) ${HOSTNAME}: Currently configured server name: $CURRENT_SERVER. Reconfiguring server.conf..."
 	cp "$SERVER_FILE" "$SERVER_FILE".$(date +"%m%d%Y")
 	sed -i "s/$CURRENT_SERVER/$HOSTNAME/" "$SERVER_FILE"
 	touch "$RESTART_SERVER_CHECK"

--- a/bin/regenGUID.ps1
+++ b/bin/regenGUID.ps1
@@ -4,7 +4,7 @@ $INSTANCE_CHECK = {$(Test-Path "$INSTANCE_FILE.*")}
 $RESTART_CHECK = "$SPLUNKHOME\etc\restartguid.txt"
 
 ### Filter to attach timestamps where necessary
-filter timestamp {"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff') ${env:COMPUTERNAME}: $_"}
+filter timestamp {"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff zzz') ${env:COMPUTERNAME}: $_"}
 
 ### Check to see if the GUID has already been replaced on this host previously by this script
 if ($INSTANCE_CHECK -eq "True") {

--- a/bin/regenGUID.sh
+++ b/bin/regenGUID.sh
@@ -5,10 +5,10 @@ RESTART_CHECK="$SPLUNK_HOME/etc/restartguid.txt"
 
 ### Check if there is already a backup of the instance.cfg and take the appropriate action.
 if [ -f "${INSTANCE}.*" ]; then
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: Instance GUID has already been changed."
+	echo "$(date -R) ${HOSTNAME}: Instance GUID has already been changed."
 	CHECK="0"
 else
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: Backing up instance.cfg"
+	echo "$(date -R) ${HOSTNAME}: Backing up instance.cfg"
 	mv "$INSTANCE" "${INSTANCE}.$(date +"%m%d%Y")"
 	touch $RESTART_CHECK
 fi

--- a/bin/restart.ps1
+++ b/bin/restart.ps1
@@ -11,7 +11,7 @@ $restartGUID = $(Test-Path "$SPLUNKHOME\etc\restartguid.txt" -PathType Leaf)
 $restartDateTime = $(Test-Path "$SPLUNKHOME\etc\restartdatetime.txt" -PathType Leaf)
 
 ### Filter to attach timestamps where necessary
-filter timestamp {"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff') ${env:COMPUTERNAME}: $_"}
+filter timestamp {"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff zzz') ${env:COMPUTERNAME}: $_"}
 
 if ($restartInput -eq "True" -OR $restartServer -eq "True" -OR $restartDS -eq "True" -OR $restartGUID -eq "True" -OR $restartDateTime -eq "True") {
 	Write-output "One or more settings has been changed." | timestamp

--- a/bin/restart.sh
+++ b/bin/restart.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-### Source the appPath script to pull proper app context
-source appContext.sh
+### Source the appContext script to pull proper app context
+. $(dirname $0)/appContext.sh
 
 ### Configure the path to the restart_check.txt file on the system
 RESTARTINPUT="$SPLUNK_HOME/etc/restartinput.txt"
@@ -11,8 +11,8 @@ RESTARTDATETIME="$SPLUNK_HOME/etc/restartdatetime.txt"
 
 ### If any files exist, restart forwarder
 if [ -f "$RESTARTINPUT" ] || [ -f "$RESTARTSERVER" ] || [ -f "$RESTARTDS" ] || [ -f "$RESTARTGUID" ] || [ -f "$RESTARTDATETIME" ]; then
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: One or more settings has been changed."
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: Restarting forwarder."
+	echo "$(date -R) ${HOSTNAME}: One or more settings has been changed."
+	echo "$(date -R) ${HOSTNAME}: Restarting forwarder."
 	if [ -f "$RESTARTINPUT" ]; then
 		rm -f "$RESTARTINPUT"
 	fi
@@ -28,8 +28,8 @@ if [ -f "$RESTARTINPUT" ] || [ -f "$RESTARTSERVER" ] || [ -f "$RESTARTDS" ] || [
 	if [ -f "$RESTARTDATETIME" ]; then
 		rm -f "$RESTARTDATETIME"
 	fi
-	rm -f "${APP_PATH}/DeleteMeToRestart"
+	rm -f "${APP_PATH}/bin/DeleteMeToRestart"
 else
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: No settings have been changed."
-	echo "$(date +"%Y-%m-%d %H:%M:%S.%3N") ${HOSTNAME}: No restart required."
+	echo "$(date -R) ${HOSTNAME}: No settings have been changed."
+	echo "$(date -R) ${HOSTNAME}: No restart required."
 fi

--- a/default/inputs.conf
+++ b/default/inputs.conf
@@ -51,6 +51,8 @@ index = _internal
 sourcetype = ds_remove:output
 interval = -1
 source = ds_remove_output
+deploymentServerUri =
+deploymentClientApp = 
 
 [powershell://dsRemove]
 disabled = 1

--- a/default/inputs.conf
+++ b/default/inputs.conf
@@ -52,7 +52,7 @@ sourcetype = ds_remove:output
 interval = -1
 source = ds_remove_output
 deploymentServerUri =
-deploymentClientApp = 
+deploymentClientApp =
 
 [powershell://dsRemove]
 disabled = 1
@@ -60,6 +60,8 @@ index = _internal
 sourcetype = ds_remove:output
 source = ds_remove_output
 script = . "$SplunkHome\etc\apps\SplunkForwarderRepairKit\bin\dsRemove.ps1"
+deploymentServerUri =
+deploymentClientApp = 
 
 ### Scripts used to correct issues with datetime.xml
 ### https://docs.splunk.com/Documentation/Splunk/latest/ReleaseNotes/FixDatetimexml2020


### PR DESCRIPTION
- Synchronized date format across shell scripts
- Added logic to remove multiple deployment client configurations in apps that are not put into a desired app or are not configured with the correct deployment server URI
- Introducing the capability to define the desired deployment server URI and deployed app to the inputs.conf file to do proper comparisons
- Adjusted the date format in all Powershell scripts to include timezone offset
- Added more logic to dsRemove.ps1 to account for existing configurations on the host and removing all configurations at once
- Added a bailout if inputs.conf configurations are not present for dsReplace scripts
- Created inputs.conf.spec file to include new settings for correcting deployment server configurations